### PR TITLE
use spawn instead of exec to start $EDITOR, to support terminal editors

### DIFF
--- a/notes/index.js
+++ b/notes/index.js
@@ -105,10 +105,17 @@ ReleaseNotesGenerator.prototype.generateNotes = function() {
       fs.writeSync(info.fd, self.notesContent);
       fs.closeSync(info.fd);
 
-      childProcess.exec(process.env.EDITOR + ' "' + info.path + '"', function(err, stdout, stderr) {
-        if (err) {
+      childProcess.spawn(process.env.EDITOR, [info.path], {
+        stdio: [
+          process.stdin,
+          process.stdout,
+          process.stderr
+        ]
+      })
+      .on('error', function(err) {
           throw err;
-        }
+      })
+      .on('exit', function() {
 
         self.notesContent = fs.readFileSync(info.path).toString();
         if (!self.notesContent) {


### PR DESCRIPTION
you need to redirect the stdio, which is only supported in `spawn`
