### PR TITLE
Use more reliable url to fetch pull commits

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -154,7 +154,7 @@ module.exports = {
                 pulls[issue.index] = pull;
                 links = extractLinks(pull.body, links);
 
-                fetchGithub(pull.commits_url, function(data) {
+                fetchGithub(pull.url + '/commits', function(data) {
                   var pullCommits = _.pluck(data, 'sha');
                   commits = _.filter(commits, function(commit) {
                     return !listHasSha(pullCommits, commit.sha);


### PR DESCRIPTION
`pull.commits_url` returns html url in github enterprise for some reason. `pull.url + ‘/commits’` seems to work in both public github and github enterprise.